### PR TITLE
Rebuild due to labwc/labwc#792

### DIFF
--- a/labwc-actions.5.html
+++ b/labwc-actions.5.html
@@ -136,7 +136,7 @@ a:hover {
 <p>Kill the process associated with the current window by sending it the
 SIGTERM signal.</p>
 </blockquote>
-<p><strong>&lt;action name="Execute"&gt;&lt;command&gt;</strong></p>
+<p><strong>&lt;action name="Execute" command="value" /&gt;</strong></p>
 <blockquote>
 <p>Execute command. Note that in the interest of backward compatibility,
 labwc supports &lt;execute&gt; as an alternative to &lt;command&gt; even
@@ -162,8 +162,8 @@ though openbox documentation states that it is deprecated.</p>
 <blockquote>
 <p>Begin interactive move of window under cursor</p>
 </blockquote>
-<p><strong>&lt;action
-name="MoveToEdge"&gt;&lt;direction&gt;</strong></p>
+<p><strong>&lt;action name="MoveToEdge" direction="value"
+/&gt;</strong></p>
 <blockquote>
 <p>Move window to edge of outputs. Understands directions "left", "up",
 "right" and "down".</p>
@@ -172,13 +172,13 @@ name="MoveToEdge"&gt;&lt;direction&gt;</strong></p>
 <blockquote>
 <p>Begin interactive resize of window under cursor</p>
 </blockquote>
-<p><strong>&lt;action
-name="SnapToEdge"&gt;&lt;direction&gt;</strong></p>
+<p><strong>&lt;action name="SnapToEdge" direction="value"
+/&gt;</strong></p>
 <blockquote>
 <p>Resize window to fill half the output in the given direction.
 Supports directions "left", "up", "right", "down" and "center".</p>
 </blockquote>
-<p><strong>&lt;action name="SnapToRegion" region="snap-1"
+<p><strong>&lt;action name="SnapToRegion" region="value"
 /&gt;</strong></p>
 <blockquote>
 <p>Resize and move active window according to the given region. See
@@ -196,7 +196,7 @@ labwc-config(5) for further information on how to define regions.</p>
 <blockquote>
 <p>Re-load configuration and theme files.</p>
 </blockquote>
-<p><strong>&lt;action name="ShowMenu"&gt;&lt;menu&gt;</strong></p>
+<p><strong>&lt;action name="ShowMenu" menu="value" /&gt;</strong></p>
 <blockquote>
 <p>Show menu. Valid menu names are "root-menu" and "client-menu".</p>
 </blockquote>
@@ -216,13 +216,13 @@ labwc-config(5) for further information on how to define regions.</p>
 <blockquote>
 <p>Toggle always-on-top of focused window.</p>
 </blockquote>
-<p><strong>&lt;action name="GoToDesktop"&gt;&lt;to&gt;</strong></p>
+<p><strong>&lt;action name="GoToDesktop" to="value" /&gt;</strong></p>
 <blockquote>
 <p>Switch to workspace. Supported values are "last", "left", "right" or
 the full name of a workspace or its index (starting at 1) as configured
 in rc.xml.</p>
 </blockquote>
-<p><strong>&lt;action name="SendToDesktop"&gt;&lt;to&gt;</strong></p>
+<p><strong>&lt;action name="SendToDesktop" to="value" /&gt;</strong></p>
 <blockquote>
 <p>Send active window to workspace. Supported values are the same as for
 GoToDesktop.</p>


### PR DESCRIPTION
Rebuild due to labwc/labwc#792

I am not sure what happened with some of the linebreaks here.
My scd files look fine, e.g. they have the linebreaks in place, however pandoc ignores them.

Any clues?