### PR TITLE
feat: implement og protocol meta tags and add a favicon

### DIFF
--- a/src/template_pre.html
+++ b/src/template_pre.html
@@ -3,7 +3,7 @@
 <head>
 <title>labwc</title>
 <meta charset="utf-8" />
-<meta name="description" content="labwc"/>
+<meta name="description" content="An Openbox inspired wlroots-based stacking Wayland compositor."/>
 <meta name="viewport" content="width=device-width">
 <link rel="icon" type="image/png" href="img/labwc.png">
 <!-- Open Graph protocol -->
@@ -11,7 +11,7 @@
 <meta property="og:type" content="website" />
 <meta property="og:image" content="img/labwc2-with-text.png" />
 <meta property="og:url" content="https://labwc.github.io" />
-<meta property="og:description" content="labwc" />
+<meta property="og:description" content="An Openbox inspired wlroots-based stacking Wayland compositor." />
 <style>
 body {
 	overflow-y: scroll;

--- a/src/template_pre.html
+++ b/src/template_pre.html
@@ -5,6 +5,13 @@
 <meta charset="utf-8" />
 <meta name="description" content="labwc"/>
 <meta name="viewport" content="width=device-width">
+<link rel="icon" type="image/png" href="img/labwc.png">
+<!-- Open Graph protocol -->
+<meta property="og:title" content="labwc" />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="img/labwc2-with-text.png" />
+<meta property="og:url" content="https://labwc.github.io" />
+<meta property="og:description" content="labwc" />
 <style>
 body {
 	overflow-y: scroll;


### PR DESCRIPTION
Adds a favicon for the website (https://github.com/labwc/labwc.github.io/blob/main/deploy/img/labwc.png)
Implements Open Graph protocol meta tags in `template-pre.html`:
- `og:title`: labwc
- `og:type`: website
- `og:url`: https://labwc.github.io
- `og:image`:
- `og:description`: ~~labwc~~ An Openbox inspired wlroots-based stacking Wayland compositor.

Pending things:
- [ ] Make image of 1:9:1 (1200x630). By having the font of labwc2-with-text.png I could do it myself
- [x] Think of a description: I've thought of the one on github (` A Wayland window-stacking compositor `) or from the README (`Lab Wayland Compositor`). This description could be also added to the meta tag `description` (not OG)