### PR TITLE
Update tips-and-tricks.md

### DIFF
--- a/src/tips-and-tricks.md
+++ b/src/tips-and-tricks.md
@@ -16,7 +16,7 @@ example, the `<c>` element below would be assigned the nodename `c.b.a`:
   <b>
     <c>foo</c>
   </b>
-<a>
+</a>
 ```
 
 `labwc` also parses XML in an element/attribute agnostic way, which means that


### PR DESCRIPTION
A slash was missing from the example. Cosmetic more than anything, but could confuse someone unfamiliar with xml.