### PR TITLE
ci: use actions/upload-pages-artifact@v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,9 +37,10 @@ jobs:
         run: ./build-site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'deploy'
+          overwrite: true
 
   deploy:
     needs: build


### PR DESCRIPTION
...because previous versions will stop working from January 2024.

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md