### PR TITLE
integration: improve Gtk>Compose subsection and Input Method section

### DIFF
--- a/src/integration.md
+++ b/src/integration.md
@@ -379,8 +379,9 @@ depending on your system setup. There are at least two ways to fallback to a
 
 ## 12.2 Compose
 
-From version `4.20.0`, accented characters cannot be typed in GTK4 applications
-without using the `ibus` package. See [#3068] for details.
+From version `4.20.0`, compose keys (e.g. typing "à" with "\`" + "a" in
+US-intl layout) do not work in GTK4 applications without using
+[input methods](#input-method) like Fcitx5 and IBus. See [#3068] for details.
 
 [#3068]: https://github.com/labwc/labwc/issues/3068
 


### PR DESCRIPTION
The 1st commit simplifies Input Method section, because:
- Setting environment variables like `GTK_IM_MODULE=fcitx` is now discouraged by Fcitx5
- IBus now supports input-method-v2 protocol
- Chromium now supports text-input-v3 protocol

The 2nd commit improves Gtk>Compose subsection:
- Mention fcitx5 along with ibus
- Fix "accented characters cannot be typed" sounded inaccurate because language-specific layout still allows to type accented characters without compose keys